### PR TITLE
Add support and testing for AvgPool2d

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,12 +10,14 @@ class Net(nn.Module):
         self.bn = nn.BatchNorm2d(64)
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.avgpool = nn.AvgPool2d(kernel_size=3, stride=2, padding=1)
 
     def forward(self, x):
         y = self.conv(x)
         y = self.bn(y)
         y = self.relu(y)
         y = self.maxpool(y)
+        y = self.avgpool(y)
         return y
 
 

--- a/torch_receptive_field/receptive_field.py
+++ b/torch_receptive_field/receptive_field.py
@@ -42,13 +42,18 @@ def receptive_field(model, input_size, batch_size=-1, device="cuda"):
                 p_j = receptive_field[p_key]["j"]
                 p_r = receptive_field[p_key]["r"]
                 p_start = receptive_field[p_key]["start"]
-                
-                if class_name == "Conv2d" or class_name == "MaxPool2d":
+
+                if class_name == "Conv2d" or class_name == "MaxPool2d" or class_name == "AvgPool2d":
                     kernel_size = module.kernel_size
                     stride = module.stride
                     padding = module.padding
-                    dilation = module.dilation
-       
+
+                    if class_name == "AvgPool2d":
+                        # Avg Pooling does not have dilation, set it to 1 (no dilation)
+                        dilation = 1
+                    else:
+                        dilation = module.dilation
+
                     kernel_size, stride, padding, dilation = map(check_same, [kernel_size, stride, padding, dilation])
                     receptive_field[m_key]["j"] = p_j * stride
                     receptive_field[m_key]["r"] = p_r + ((kernel_size - 1) * dilation) * p_j


### PR DESCRIPTION
Previously, if we use `receptive_field()` on a model with avg pooling layers, the script will raise an exception saying "module not ok" on line 66 of receptive_field.py.

This pull request adds support for AvgPool2d layers.