### PR TITLE
support 1-d CNN and support any device type available in pytorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,60 @@ Receptive field size for layer 2, unit_position (1, 1, 1),  is
  [(0, 3.0), (0, 3.0), (0, 3.0)]
 ```
 
+## Example 1D CNN
+```python
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch_receptive_field import receptive_field
+
+class Net1D(nn.Module):
+    def __init__(self):
+        super(Net1D, self).__init__()
+        self.conv = nn.Conv1d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
+        self.bn = nn.BatchNorm1d(64)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool1d(kernel_size=3, stride=2, padding=1)
+        self.avgpool = nn.AvgPool1d(kernel_size=3, stride=2, padding=1)
+
+    def forward(self, x):
+        y = self.conv(x)
+        y = self.bn(y)
+        y = self.relu(y)
+        y = self.maxpool(y)
+        y = self.avgpool(y)
+        return y
+
+device = "cpu"
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+
+print(f"--> Using device: {device}")
+
+model = Net1D().to(device)
+receptive_field_dict = receptive_field(model, (3, 256), device=device)
+receptive_field_for_unit(receptive_field_dict, "2", (1,))
+
+```
+```
+--> Using device: mps
+------------------------------------------------------------------------------
+        Layer (type)    map size      start       jump receptive_field 
+==============================================================================
+        0                  [256]        0.5        1.0             1.0 
+        1                  [128]        0.5        2.0             7.0 
+        2                  [128]        0.5        2.0             7.0 
+        3                  [128]        0.5        2.0             7.0 
+        4                   [64]        0.5        4.0            11.0 
+        5                   [32]        0.5        8.0            19.0 
+==============================================================================
+Receptive field size for layer 2, unit_position (1,),  is 
+ [(0, 6.0)]
+```
+
 ## Related
 Thanks @pytorch-summary
 

--- a/main.py
+++ b/main.py
@@ -3,9 +3,27 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch_receptive_field import receptive_field, receptive_field_for_unit, receptive_field_visualization_2d
 
-class Net(nn.Module):
+
+class Net1D(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super(Net1D, self).__init__()
+        self.conv = nn.Conv1d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
+        self.bn = nn.BatchNorm1d(64)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool1d(kernel_size=3, stride=2, padding=1)
+        self.avgpool = nn.AvgPool1d(kernel_size=3, stride=2, padding=1)
+
+    def forward(self, x):
+        y = self.conv(x)
+        y = self.bn(y)
+        y = self.relu(y)
+        y = self.maxpool(y)
+        y = self.avgpool(y)
+        return y
+    
+class Net2D(nn.Module):
+    def __init__(self):
+        super(Net2D, self).__init__()
         self.conv = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
         self.bn = nn.BatchNorm2d(64)
         self.relu = nn.ReLU(inplace=True)
@@ -36,8 +54,12 @@ class Net3D(nn.Module):
         return y
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu") # PyTorch v0.4.0
-model = Net().to(device)
 
+model = Net1D().to(device)
+receptive_field_dict = receptive_field(model, (3, 256))
+receptive_field_for_unit(receptive_field_dict, "2", (1,))
+
+model = Net2D().to(device)
 receptive_field_dict = receptive_field(model, (3, 256, 256))
 receptive_field_for_unit(receptive_field_dict, "2", (1,1))
 receptive_field_visualization_2d(receptive_field_dict, "./examples/example.jpg", "example_receptive_field_2d")

--- a/main.py
+++ b/main.py
@@ -53,17 +53,24 @@ class Net3D(nn.Module):
         y = self.maxpool(y)
         return y
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu") # PyTorch v0.4.0
+device = "cpu"
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+
+print(f"--> Using device: {device}")
 
 model = Net1D().to(device)
-receptive_field_dict = receptive_field(model, (3, 256))
+receptive_field_dict = receptive_field(model, (3, 256), device=device)
 receptive_field_for_unit(receptive_field_dict, "2", (1,))
 
 model = Net2D().to(device)
-receptive_field_dict = receptive_field(model, (3, 256, 256))
+receptive_field_dict = receptive_field(model, (3, 256, 256), device=device)
 receptive_field_for_unit(receptive_field_dict, "2", (1,1))
 receptive_field_visualization_2d(receptive_field_dict, "./examples/example.jpg", "example_receptive_field_2d")
 
 model = Net3D().to(device)
-receptive_field_dict = receptive_field(model, (3, 16, 16, 16))
+receptive_field_dict = receptive_field(model, (3, 16, 16, 16), device=device)
 receptive_field_for_unit(receptive_field_dict, "2", (1,1,1))

--- a/torch_receptive_field/receptive_field.py
+++ b/torch_receptive_field/receptive_field.py
@@ -144,7 +144,7 @@ def receptive_field(model, input_size, batch_size=-1, device="cuda"):
     # else:
     #     x = Variable(torch.rand(2, *input_size)).type(dtype)
 
-    x = torch.rand(2, *input_size, device=device)
+    x = torch.rand(1, *input_size, device=device)
 
     current_device = next(model.parameters()).device.type
     if current_device != device:

--- a/torch_receptive_field/receptive_field.py
+++ b/torch_receptive_field/receptive_field.py
@@ -126,23 +126,31 @@ def receptive_field(model, input_size, batch_size=-1, device="cuda"):
         ):
             hooks.append(module.register_forward_hook(hook))
 
-    device = device.lower()
-    assert device in [
-        "cuda",
-        "cpu",
-        "mps"
-    ], "Input device is not valid, please specify 'cuda' or 'cpu'"
+    # device = device.lower()
+    # assert device in [
+    #     "cuda",
+    #     "cpu",
+    #     "mps"
+    # ], "Input device is not valid, please specify 'cuda' or 'cpu'"
 
-    if device == "cuda" and torch.cuda.is_available():
-        dtype = torch.cuda.FloatTensor
-    else:
-        dtype = torch.FloatTensor
+    # if device == "cuda" and torch.cuda.is_available():
+    #     dtype = torch.cuda.FloatTensor
+    # else:
+    #     dtype = torch.FloatTensor
 
-    # check if there are multiple inputs to the network
-    if isinstance(input_size[0], (list, tuple)):
-        x = [Variable(torch.rand(2, *in_size)).type(dtype) for in_size in input_size]
-    else:
-        x = Variable(torch.rand(2, *input_size)).type(dtype)
+    # # check if there are multiple inputs to the network
+    # if isinstance(input_size[0], (list, tuple)):
+    #     x = [Variable(torch.rand(2, *in_size)).type(dtype) for in_size in input_size]
+    # else:
+    #     x = Variable(torch.rand(2, *input_size)).type(dtype)
+
+    x = torch.rand(2, *input_size, device=device)
+
+    current_device = next(model.parameters()).device.type
+    if current_device != device:
+        model.to(device)
+        
+    model.eval()
 
     # create properties
     receptive_field = OrderedDict()
@@ -159,7 +167,8 @@ def receptive_field(model, input_size, batch_size=-1, device="cuda"):
     model.apply(register_hook)
 
     # make a forward pass
-    model(x)
+    with torch.no_grad():
+        model(x)
 
     # remove these hooks
     for h in hooks:


### PR DESCRIPTION
- support 1-d CNN (Conv1d, MaxPool1d, AvgPool1d); also support normalization layers, linear layers, dropout layers, considering these layers as `pointwise_operations` which will not change `jump` and `receptive_field`
- support any device type available in pytorch